### PR TITLE
Release 1.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script: if [ "$VAADIN_CHARTS_LICENSE_CODE" != "" ]; then
                fi;
 
 # as agreed in our SOP, build everything (don't deploy, just try to 'mvn package' locally, which covers unit tests)
-script: mvn --quiet --activate-profiles !development-build,!release-build --settings .travis.settings.xml clean cobertura:cobertura package
+script: mvn --activate-profiles !development-build,!release-build --settings .travis.settings.xml clean cobertura:cobertura package
 # upload code coverage report, generate maven site (javadocs, documentation, static code analysis, etc.)
 after_success: 
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ deploy:
 # activate our conda environment, generate maven site and upload reports to gh-pages branch
 after_deploy:   
   - echo ". $HOME/miniconda3/etc/profile.d/conda.sh" >> ~/.bashrc && source ~/.bashrc && conda activate qbic-docs-build
-  - mvn --quiet --activate-profiles !development-build,!release-build --settings .travis.settings.xml site 
+  - mvn --activate-profiles !development-build,!release-build --settings .travis.settings.xml site 
   - ./.generate-reports.py $TRAVIS_BRANCH $TRAVIS_REPO_SLUG "[skip travis] Updated gh-pages" "This commit was performed from travis-ci.com using a personal access key" "Build ID $TRAVIS_BUILD_ID" "Job ID TRAVIS_JOB_ID" "Branch $TRAVIS_BRANCH" "Log of this build found at $TRAVIS_JOB_WEB_URL"
 
 # credentials

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>life.qbic</groupId>
 	<artifactId>projectbrowser-portlet</artifactId>
-	<version>1.10.0-SNAPSHOT</version>
+	<version>1.11.0-SNAPSHOT</version>
 	<name>ProjectBrowser Portlet</name>
 	<url>http://github.com/qbicsoftware/projectbrowser-portlet</url>
 	<description>Browse and manage biomedical projects</description>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>life.qbic</groupId>
 	<artifactId>projectbrowser-portlet</artifactId>
-	<version>1.9.3</version>
+	<version>1.10.0-SNAPSHOT</version>
 	<name>ProjectBrowser Portlet</name>
 	<url>http://github.com/qbicsoftware/projectbrowser-portlet</url>
 	<description>Browse and manage biomedical projects</description>

--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,12 @@
 		<dependency>
 			<groupId>life.qbic</groupId>
 			<artifactId>portal-utils-lib</artifactId>
-			<version>1.6.0</version>
+			<version>1.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>life.qbic</groupId>
 			<artifactId>core-utils-lib</artifactId>
-			<version>1.0.0</version>
+			<version>1.2.1</version>
 		</dependency>
 
 		<!-- openBIS client (version defined in parent POM) -->

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>life.qbic</groupId>
 	<artifactId>projectbrowser-portlet</artifactId>
-	<version>1.11.0-SNAPSHOT</version>
+	<version>1.11.0</version>
 	<name>ProjectBrowser Portlet</name>
 	<url>http://github.com/qbicsoftware/projectbrowser-portlet</url>
 	<description>Browse and manage biomedical projects</description>

--- a/src/main/java/life/qbic/portal/portlet/ProjectBrowserPortlet.java
+++ b/src/main/java/life/qbic/portal/portlet/ProjectBrowserPortlet.java
@@ -25,6 +25,7 @@ import life.qbic.portal.utils.PortalUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.HashMap;
@@ -88,6 +89,19 @@ public class ProjectBrowserPortlet extends QBiCPortletUI {
     LOG.info("Generating content for {}", ProjectBrowserPortlet.class);
 
     manager = ConfigurationManagerFactory.getInstance();
+    
+    // initialize tmp folder
+    try {
+      File tmpFolder = new File(manager.getTmpFolder());
+      if (!tmpFolder.exists()) {
+        tmpFolder.mkdirs();
+      }
+    } catch (Exception e) {
+      LOG.warn("unsuccessfully tried to initialize temporary folder:"+manager.getTmpFolder());
+      LOG.warn(e.getMessage());
+    }
+
+    
     // check if we are allowed to display content to unauthenticated users
     if (PortalUtils.isLiferayPortlet() && PortalUtils.getUser() == null) {
       final ConfigurationManager configurationManager = ConfigurationManagerFactory.getInstance();

--- a/src/main/java/life/qbic/projectbrowser/components/ProjInformationComponent.java
+++ b/src/main/java/life/qbic/projectbrowser/components/ProjInformationComponent.java
@@ -276,7 +276,7 @@ public class ProjInformationComponent extends CustomComponent {
       // need to be disabled first so old project tsvs are not downloadable
       tsvDownloadContent.disableSpreadSheets();
       tsvDownloadContent.prepareSpreadsheets(types, space, project, datahandler.getOpenBisClient(),
-          datahandler.getFactorLabels(), datahandler.getFactorsForLabelsAndSamples());
+          datahandler.getFactorLabels(), datahandler.getFactorsForLabelsAndSamples(), datahandler.getPropertiesForSamples());
       tsvDownloadContent.setVisible(true);
     } else {
       // nothing to create a tsv from

--- a/src/main/java/life/qbic/projectbrowser/components/TSVDownloadComponent.java
+++ b/src/main/java/life/qbic/projectbrowser/components/TSVDownloadComponent.java
@@ -17,15 +17,13 @@ package life.qbic.projectbrowser.components;
 
 import com.vaadin.ui.UI;
 import life.qbic.openbis.openbisclient.OpenBisClient;
-
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import life.qbic.projectbrowser.helpers.TSVReadyRunnable;
-
 import com.vaadin.server.FileDownloader;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.server.StreamResource;
@@ -34,7 +32,6 @@ import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ValoTheme;
 import life.qbic.xml.properties.Property;
-
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -96,14 +93,15 @@ public class TSVDownloadComponent extends VerticalLayout {
 
   public void prepareSpreadsheets(final List<String> sampleTypes, String space,
       final String project, final OpenBisClient openbis, final Set<String> factors,
-      final Map<Pair<String, String>, Property> factorsForLabelsAndSamples) {
+      final Map<Pair<String, String>, Property> factorsForLabelsAndSamples,
+      Map<String, List<Property>> samplesToProperties) {
     final TSVDownloadComponent layout = this;
 
     final Thread t = new Thread(() -> {
       Map<String, String> tables = new HashMap<String, String>();
       for (String type : sampleTypes) {
         tables.put(type, getTSVString(openbis.getProjectTSV(project, type), factors,
-            factorsForLabelsAndSamples));
+            factorsForLabelsAndSamples, samplesToProperties));
       }
       UI.getCurrent().access(new TSVReadyRunnable(layout, tables, project));
       UI.getCurrent().setPollInterval(-1);
@@ -113,7 +111,8 @@ public class TSVDownloadComponent extends VerticalLayout {
   }
 
   private static String getTSVString(List<String> table, Set<String> factors,
-      Map<Pair<String, String>, Property> factorsForLabelsAndSamples) {
+      Map<Pair<String, String>, Property> factorsForLabelsAndSamples,
+      Map<String, List<Property>> samplesToProperties) {
 
     final StringBuilder header = new StringBuilder(table.get(0).replace("\tAttributes", ""));
     final StringBuilder tsv = new StringBuilder();
@@ -123,11 +122,17 @@ public class TSVDownloadComponent extends VerticalLayout {
     List<String> labels = new ArrayList<>();
     // header
 
+    Set<String> sampleCodes = new HashSet<>();
+    Set<String> propertyLabels = new HashSet<>();
+    for (String row : table) {
+      String[] lineSplit = row.split("\t", -1);// doesn't remove trailing whitespaces
+      String code = lineSplit[0];
+      sampleCodes.add(code);
+    }
+
     for (String label : factors) {
       boolean used = false;
-      for (String row : table) {
-        String[] lineSplit = row.split("\t", -1);// doesn't remove trailing whitespaces
-        String code = lineSplit[0];
+      for (String code : sampleCodes) {
         if (factorsForLabelsAndSamples.get(new ImmutablePair<>(label, code)) != null) {
           used = true;
           break;
@@ -138,37 +143,25 @@ public class TSVDownloadComponent extends VerticalLayout {
         header.append("\tCondition: " + label);
       }
     }
-    // final List<String> factorLabels = new ArrayList<String>();
-    // for (String row : table) {
-    // String[] lineSplit = row.split("\t", -1);// doesn't remove trailing whitespaces
-    // String xml = "";
-    // for (String cell : lineSplit) {
-    // if (cell.startsWith(xmlStart))
-    // xml = cell;
-    // }
-    // List<Property> factors = new ArrayList<Property>();
-    // if (!xml.equals(xmlStart)) {
-    // try {
-    // factors = p.getAllPropertiesFromXML(xml);
-    // } catch (JAXBException e) {
-    // LOG.warn("Could not retrieve properties from xml", e);
-    // }
-    // for (Property f : factors) {
-    // String label = f.getLabel();
-    // if (!factorLabels.contains(label)) {
-    // factorLabels.add(label);
-    // header.append("\tCondition: ").append(label);
-    // }
-    // }
-    // }
-    // }
+
+    // first collect all properties used on this level of the experiment
+    for (String code : sampleCodes) {
+      for (Property p : samplesToProperties.get(code)) {
+        String label = p.getLabel();
+        propertyLabels.add(label);
+      }
+    }
+    // then determine an ordering for header and data
+    List<String> propLabelsOrdered = new ArrayList<>(propertyLabels);
+    for (String propLabel : propLabelsOrdered) {
+      header.append("\tProperty: " + propLabel);
+    }
 
     // data
-
     for (String row : table) {
       String[] lineSplit = row.split("\t", -1);// doesn't remove trailing whitespaces
       String xml = "";
-      String code = lineSplit[0];
+      String sampleCode = lineSplit[0];
       for (String cell : lineSplit) {
         if (cell.startsWith(xmlStart))
           xml = cell;
@@ -177,7 +170,7 @@ public class TSVDownloadComponent extends VerticalLayout {
       StringBuilder line = new StringBuilder("\n" + row);
 
       for (String label : labels) {
-        Property f = factorsForLabelsAndSamples.get(new ImmutablePair<>(label, code));
+        Property f = factorsForLabelsAndSamples.get(new ImmutablePair<>(label, sampleCode));
         if (f != null) {
           line.append("\t" + f.getValue());
           if (f.hasUnit())
@@ -187,42 +180,22 @@ public class TSVDownloadComponent extends VerticalLayout {
         }
       }
 
-      // for (String row : table) {
-      // String[] lineSplit = row.split("\t", -1);// doesn't remove trailing whitespaces
-      // String xml = "";
-      // for (String cell : lineSplit) {
-      // if (cell.startsWith(xmlStart))
-      // xml = cell;
-      // }
-      // row = row.replace("\t" + xml, "");
-      // StringBuilder line = new StringBuilder("\n" + row);
-      // List<Property> factors = new ArrayList<Property>();
-      // if (!xml.equals(xmlStart)) {
-      // try {
-      // factors = p.getAllPropertiesFromXML(xml);
-      // } catch (JAXBException e) {
-      // LOG.warn("Could not retrieve properties from xml", e);
-      // }
-      // Map<Integer, Property> order = new HashMap<Integer, Property>();
-      // for (Property f : factors) {
-      // String label = f.getLabel();
-      // order.put(factorLabels.indexOf(label), f);
-      // }
-      // for (int i = 0; i < factorLabels.size(); i++) {
-      // if (order.containsKey(i)) {
-      // Property f = order.get(i);
-      // line.append("\t" + f.getValue());
-      // if (f.hasUnit())
-      // line.append(f.getUnit());
-      // } else {
-      // line.append("\t");
-      // }
-      // }
-      // } else {
-      // for (int i = 0; i < factorLabels.size() - 1; i++) {
-      // line.append("\t");
-      // }
-      // }
+      for (String propLabel : propertyLabels) {
+        boolean found = false;
+        for (Property p : samplesToProperties.get(sampleCode)) {
+          if (p.getLabel().equals(propLabel)) {
+            line.append("\t" + p.getValue());
+            if (p.hasUnit())
+              line.append(p.getUnit());
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          line.append("\t");
+        }
+      }
+
       tsv.append(line);
     }
     return header.append(tsv).toString();

--- a/src/main/java/life/qbic/projectbrowser/components/TSVDownloadComponent.java
+++ b/src/main/java/life/qbic/projectbrowser/components/TSVDownloadComponent.java
@@ -146,9 +146,11 @@ public class TSVDownloadComponent extends VerticalLayout {
 
     // first collect all properties used on this level of the experiment
     for (String code : sampleCodes) {
-      for (Property p : samplesToProperties.get(code)) {
-        String label = p.getLabel();
-        propertyLabels.add(label);
+      if (samplesToProperties.containsKey(code)) {
+        for (Property p : samplesToProperties.get(code)) {
+          String label = p.getLabel();
+          propertyLabels.add(label);
+        }
       }
     }
     // then determine an ordering for header and data

--- a/src/main/java/life/qbic/projectbrowser/controllers/DataHandler.java
+++ b/src/main/java/life/qbic/projectbrowser/controllers/DataHandler.java
@@ -16,7 +16,6 @@
 package life.qbic.projectbrowser.controllers;
 
 import java.io.Serializable;
-import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -43,12 +42,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.vaadin.data.util.BeanItemContainer;
-import com.vaadin.data.util.HierarchicalContainer;
 import com.vaadin.data.util.IndexedContainer;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.server.ThemeResource;
 import com.vaadin.shared.ui.label.ContentMode;
-import com.vaadin.ui.CheckBox;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.ProgressBar;
 import com.vaadin.ui.VerticalLayout;

--- a/src/main/java/life/qbic/projectbrowser/controllers/DataHandler.java
+++ b/src/main/java/life/qbic/projectbrowser/controllers/DataHandler.java
@@ -2673,12 +2673,12 @@ public class DataHandler implements Serializable {
    * generates informative description from dataset secondary name or the dataset's experiment,
    * given its ID. should only be used if a dataset does not have an associated sample
    * 
-   * @param datasetSecondaryName
-   * @param experimentID
-   * @return
+   * @param datasetSecondaryName the secondary name property of the dataset
+   * @param experimentID the full openBIS identifier of the experiment of the dataset
+   * @return informative String describing the dataset
    */
   public String retrieveDatasetInfoWithoutSample(String datasetSecondaryName, String experimentID) {
-    // dataset name has priority
+    // if dataset name was explicitly set, give it priority
     if (datasetSecondaryName != null && !datasetSecondaryName.isEmpty()) {
       return datasetSecondaryName;
     }
@@ -2689,9 +2689,9 @@ public class DataHandler implements Serializable {
           + " not found. Returning empty metadata to display.");
       return "";
     }
-    Experiment e = experiments.get(0);
-    Map<String, String> props = e.getProperties();
-    String type = e.getExperimentTypeCode();
+    Experiment experiment = experiments.get(0);
+    Map<String, String> props = experiment.getProperties();
+    String type = experiment.getExperimentTypeCode();
     switch (type) {
       case "Q_NGS_NANOPORE_RUN":
         String res = props.get("Q_FLOWCELL_BARCODE");

--- a/src/main/java/life/qbic/projectbrowser/controllers/DataHandler.java
+++ b/src/main/java/life/qbic/projectbrowser/controllers/DataHandler.java
@@ -2231,9 +2231,11 @@ public class DataHandler implements Serializable {
       this.getOpenBisClient().triggerIngestionService("register-proj", projectMap);
       // helpers.Utils.printMapContent(projectMap);
 
-      String newProjectDetailsCode =
-          projectPrefix + Utils.createCountString(numberOfProject, 3) + "E_INFO";
-      String newProjectDetailsID = "/" + space + "/" + newProjectCode + "/" + newProjectDetailsCode;
+//      String newProjectDetailsCode =
+//          projectPrefix + Utils.createCountString(numberOfProject, 3) + "E_INFO";
+//      String newProjectDetailsID = "/" + space + "/" + newProjectCode + "/" + newProjectDetailsCode;
+      
+      String newProjectDetailsID = ExperimentCodeFunctions.getInfoExperimentID(space, newProjectCode);
 
       String newExperimentalDesignCode = projectPrefix + Utils.createCountString(numberOfProject, 3)
           + "E" + numberOfRegisteredExperiments;

--- a/src/main/java/life/qbic/projectbrowser/helpers/TSVReadyRunnable.java
+++ b/src/main/java/life/qbic/projectbrowser/helpers/TSVReadyRunnable.java
@@ -25,6 +25,7 @@ import com.vaadin.server.StreamResource;
 
 
 import life.qbic.projectbrowser.components.TSVDownloadComponent;
+import life.qbic.utils.TimeUtils;
 
 public class TSVReadyRunnable implements Runnable {
 
@@ -42,13 +43,14 @@ public class TSVReadyRunnable implements Runnable {
   @Override
   public void run() {
     List<StreamResource> streams = new ArrayList<StreamResource>();
+    String ts = TimeUtils.getCurrentTimestampString();
     streams.add(
-        getTSVStream(tableContentStrings.get("Q_BIOLOGICAL_ENTITY"), project + "_sample_sources"));
+        getTSVStream(tableContentStrings.get("Q_BIOLOGICAL_ENTITY"), project + "_sample_sources_"+ts));
     streams.add(
-        getTSVStream(tableContentStrings.get("Q_BIOLOGICAL_SAMPLE"), project + "_sample_extracts"));
+        getTSVStream(tableContentStrings.get("Q_BIOLOGICAL_SAMPLE"), project + "_sample_extracts_"+ts));
     if (tableContentStrings.containsKey("Q_TEST_SAMPLE"))
       streams.add(
-          getTSVStream(tableContentStrings.get("Q_TEST_SAMPLE"), project + "_sample_preparations"));
+          getTSVStream(tableContentStrings.get("Q_TEST_SAMPLE"), project + "_sample_preparations_"+ts));
     layout.armButtons(streams);
   }
 


### PR DESCRIPTION
- adds properties (in addition to experimental conditions) to the downloadable spreadsheets
- support for datasets without samples: displayed in the Dataset tab, the description is taken from the dataset description or, alternatively, the experiment. added support for Nanopore experiment
- downloadable spreadsheets now have timestamps in their name to fix a caching issue that would sometimes lead to old spreadsheets being downloaded