### PR TITLE
Hotfix for 2 issues introduced in 1.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>life.qbic</groupId>
 	<artifactId>projectbrowser-portlet</artifactId>
-	<version>1.11.0</version>
+	<version>1.11.1</version>
 	<name>ProjectBrowser Portlet</name>
 	<url>http://github.com/qbicsoftware/projectbrowser-portlet</url>
 	<description>Browse and manage biomedical projects</description>

--- a/src/main/java/life/qbic/projectbrowser/components/TSVDownloadComponent.java
+++ b/src/main/java/life/qbic/projectbrowser/components/TSVDownloadComponent.java
@@ -184,16 +184,20 @@ public class TSVDownloadComponent extends VerticalLayout {
 
       for (String propLabel : propertyLabels) {
         boolean found = false;
-        for (Property p : samplesToProperties.get(sampleCode)) {
-          if (p.getLabel().equals(propLabel)) {
-            line.append("\t" + p.getValue());
-            if (p.hasUnit()) {
-              line.append(p.getUnit());
+        // catch case that one sample does not have any properties
+        if (samplesToProperties.containsKey(sampleCode)) {
+          for (Property p : samplesToProperties.get(sampleCode)) {
+            if (p.getLabel().equals(propLabel)) {
+              line.append("\t" + p.getValue());
+              if (p.hasUnit()) {
+                line.append(p.getUnit());
+              }
+              found = true;
+              break;
             }
-            found = true;
-            break;
           }
         }
+        // if this sample does not have the currently handled property, skip it for this row
         if (!found) {
           line.append("\t");
         }

--- a/src/main/java/life/qbic/projectbrowser/samplegraph/ProjectParser.java
+++ b/src/main/java/life/qbic/projectbrowser/samplegraph/ProjectParser.java
@@ -11,14 +11,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-
 import javax.xml.bind.JAXBException;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.WordUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-
 import ch.systemsx.cisd.openbis.dss.client.api.v1.DataSet;
 import ch.systemsx.cisd.openbis.generic.shared.api.v1.dto.Sample;
 import life.qbic.datamodel.samples.ISampleBean;
@@ -95,17 +92,6 @@ public class ProjectParser {
       throws JAXBException {
     Pair<String, String> key = new ImmutablePair<>(factorLabel, s.getCode());
     return factorsForLabelsAndSamples.get(key);
-    // final Map<String, String> props = s.getProperties();
-    // final String xmlProperties = props.get("Q_PROPERTIES");
-    // final List<Property> factors = (xmlProperties == null ? Collections.EMPTY_LIST
-    // : xmlParser.getAllProperties(xmlParser.parseXMLString(xmlProperties)));
-    //
-    // for (final Property f : factors) {
-    // if (f.getLabel().equals(factorLabel)) {
-    // return f;
-    // }
-    // }
-    // return null;
   }
 
   public StructuredExperiment parseSamplesBreadthFirst(List<Sample> samples, List<DataSet> datasets,
@@ -116,15 +102,18 @@ public class ProjectParser {
     sampCodeToDS = new HashMap<String, List<DataSet>>();
     codesWithDatasets = new HashSet<String>();
     for (DataSet d : datasets) {
-      String code = d.getSampleIdentifierOrNull().split("/")[2];
-      if (sampCodeToDS.containsKey(code)) {
-        sampCodeToDS.get(code).add(d);
-      } else {
-        sampCodeToDS.put(code, new ArrayList<DataSet>(Arrays.asList(d)));
+      String sampleID = d.getSampleIdentifierOrNull();
+      // datasets without samples are ignored, as this is a sample graph
+      if (sampleID != null) {
+        String sampleCode = sampleID.split("/")[2];
+        if (sampCodeToDS.containsKey(sampleCode)) {
+          sampCodeToDS.get(sampleCode).add(d);
+        } else {
+          sampCodeToDS.put(sampleCode, new ArrayList<DataSet>(Arrays.asList(d)));
+        }
       }
     }
 
-    // this.xmlParser = new XMLParser();
     Map<String, List<SampleSummary>> factorsToSamples = new HashMap<String, List<SampleSummary>>();
 
     Set<String> knownFactors = new HashSet<String>();
@@ -139,16 +128,6 @@ public class ProjectParser {
       sampCodeToSamp.put(sample.getCode(), sample);
       String type = sample.getSampleTypeCode();
       if (validSamples.contains(type)) {
-        // Map<String, String> propertiesMap = sample.getProperties();
-        // List<Property> factors = new ArrayList<Property>();
-        // if (propertiesMap.containsKey("Q_PROPERTIES")) {
-        // // TODO: all props?
-        // factors = xmlParser
-        // .getAllProperties(xmlParser.parseXMLString(propertiesMap.get("Q_PROPERTIES")));
-        // }
-        // for (Property f : factors) {
-        // knownFactors.add(f.getLabel());
-        // }
         // collect roots
         if (sample.getParents().isEmpty()) {
           samplesBreadthFirst.add(sample);


### PR DESCRIPTION
- sample graph doesn't crash anymore for projects containing datasets without samples
- tsv export works now for projects containing a mix of samples with user-defined properties and samples without any such properties