### PR TITLE
don't update experimental design if changes are recent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,21 @@
 ==========
 Changelog
 ==========
+
+1.12.1 (2021-06-16)
+-------------------
+
+**Fixed**
+
+* Don't auto-update experimental design of a selected project if changes are recent, giving openBIS time to index samples
+
+1.12.0 (2021-06-07)
+-------------------
+
+**Added**
+
+* Support for new person database structure
+
 1.11.4 (2021-03-22)
 -------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>life.qbic</groupId>
 	<artifactId>projectbrowser-portlet</artifactId>
-	<version>1.11.4</version>
+	<version>1.12.1</version>
 	<name>ProjectBrowser Portlet</name>
 	<url>http://github.com/qbicsoftware/projectbrowser-portlet</url>
 	<description>Browse and manage biomedical projects</description>

--- a/src/main/java/life/qbic/projectbrowser/controllers/DataHandler.java
+++ b/src/main/java/life/qbic/projectbrowser/controllers/DataHandler.java
@@ -644,21 +644,11 @@ public class DataHandler implements Serializable {
     if (expDesign != null) {
       // experimental design found and parsed. remove references to samples that have since been
       // deleted; give openbis enough time to index samples
+      
       long creationTime = designExperiment.getRegistrationDetails().getModificationDate().getTime();
-      long currentTime = System.currentTimeMillis();
-      long elapsedTime = currentTime - creationTime;
-
-      long secondsInMilli = 1000;
-      long minutesInMilli = secondsInMilli * 60;
-      long hoursInMilli = minutesInMilli * 60;
-
-      long elapsedHours = elapsedTime / hoursInMilli;
-      boolean isOldProject = elapsedHours > RECHECK_EXPERIMENTAL_DESIGN_AFTER_HOURS;
-
-      LOG.info(elapsedHours + " hours since last modification of this experimental design.");
 
       try {
-        if (!allSampleCodes.isEmpty() && isOldProject) {
+        if (!allSampleCodes.isEmpty() && sampleReferencesNeedRefresh(creationTime)) {
           LOG.info("comparing existing samples with references in experimental design");
           if (studyParser.hasReferencesToMissingIDs(expDesign, allSampleCodes)) {
             LOG.info("deleted samples found. updating xml in openBIS");
@@ -770,6 +760,21 @@ public class DataHandler implements Serializable {
 
     newProjectBean.setSecondaryName(secondaryName);
     return newProjectBean;
+  }
+
+  private boolean sampleReferencesNeedRefresh(long creationTime) {
+    long currentTime = System.currentTimeMillis();
+    long elapsedTime = currentTime - creationTime;
+
+    long secondsInMilli = 1000;
+    long minutesInMilli = secondsInMilli * 60;
+    long hoursInMilli = minutesInMilli * 60;
+
+    long elapsedHours = elapsedTime / hoursInMilli;
+
+    LOG.info(elapsedHours + " hours since last modification of this experimental design.");
+    
+    return elapsedHours > RECHECK_EXPERIMENTAL_DESIGN_AFTER_HOURS;
   }
 
   public Project getOpenbisDtoProject(String projectIdentifier) {


### PR DESCRIPTION
Selecting a project compares available samples to their references in the experimental design xml object. References to samples that have since been removed are deleted from the xml object.

This caused a bug if samples were not yet indexed by openBIS, since they could not be found.

This PR fixes that bug by comparing the modification date of the object in openBIS and only removing references to missing samples if a certain time since modification has passed. This will most likely also speed up project loading times in most cases.