### PR TITLE
Hotfix/1.12.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog
 ==========
 
+1.12.3 (2021-12-13)
+-------------------
+
+**Dependencies**
+
+* ``com.vaadin 7.7.28`` -> ``7.7.29``
+
+* ``org.apache.logging.log4j:log4j-core:2.14.0`` -> ``2.15.0`` (addresses CVE-2021-44228)
+
+* ``org.apache.logging.log4j:log4j-api:2.14.0`` -> ``2.15.0``
+
 1.12.2 (2021-10-29)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,6 @@ Changelog
 
 **Dependencies**
 
-* ``com.vaadin 7.7.28`` -> ``7.7.29``
 
 * ``org.apache.logging.log4j:log4j-core:2.14.0`` -> ``2.15.0`` (addresses CVE-2021-44228)
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,25 @@
 	<!-- we only need to tell maven where to find our parent pom and other QBiC 
 		dependencies -->
 	<properties>
-		<vaadin.version>7.7.28</vaadin.version>
-		<vaadin.plugin.version>7.7.28</vaadin.plugin.version>
+		<vaadin.version>7.7.29</vaadin.version>
+		<vaadin.plugin.version>7.7.29</vaadin.plugin.version>
+		<log4j.version>2.15.0</log4j.version>
 	</properties>
 	<repositories>
+		<!-- maven repository -->
+		<repository>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+				<checksumPolicy>fail</checksumPolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>maven-central</id>
+			<name>Maven central</name>
+			<url>https://repo.maven.apache.org/maven2</url>
+		</repository>
 		<repository>
 			<releases>
 				<enabled>false</enabled>
@@ -32,7 +47,7 @@
 			</snapshots>
 			<id>nexus-snapshots</id>
 			<name>QBiC Snapshots</name>
-			<url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-snapshots</url>
+			<url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-snapshots</url>
 		</repository>
 		<repository>
 			<releases>
@@ -45,10 +60,13 @@
 			</snapshots>
 			<id>nexus-releases</id>
 			<name>QBiC Releases</name>
-			<url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-releases</url>
+			<url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
+		</repository>
+		<repository>
+			<id>vaadin-addons</id>
+			<url>https://maven.vaadin.com/vaadin-addons</url>
 		</repository>
 	</repositories>
-
 	<dependencies>
 		<dependency>
 			<groupId>life.qbic</groupId>
@@ -171,6 +189,18 @@
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpmime</artifactId>
 			<version>4.3.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
 	<!-- we only need to tell maven where to find our parent pom and other QBiC 
 		dependencies -->
 	<properties>
-		<vaadin.version>7.7.29</vaadin.version>
-		<vaadin.plugin.version>7.7.29</vaadin.plugin.version>
+		<vaadin.version>7.7.28</vaadin.version>
+		<vaadin.plugin.version>7.7.28</vaadin.plugin.version>
 		<log4j.version>2.15.0</log4j.version>
 	</properties>
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>life.qbic</groupId>
 	<artifactId>projectbrowser-portlet</artifactId>
-	<version>1.12.2</version>
+	<version>1.12.3</version>
 	<name>ProjectBrowser Portlet</name>
 	<url>http://github.com/qbicsoftware/projectbrowser-portlet</url>
 	<description>Browse and manage biomedical projects</description>


### PR DESCRIPTION
Note: I wasn't able to build it locally with vaadin 7.7.28 only when i changed the version the package could be build. 
I  get the following error with the vaadin 7.7.28 version: 
```
([ERROR] SEVERE: Mixin Definition: valo not found
[ERROR] Compiling theme "VAADIN/themes/mytheme" failed
org.codehaus.mojo.gwt.shell.JavaCommandException)
```
However @jenniferboedker was able to build it locally with the vaadin 7.7.28 version. 

Changelog
==========

1.12.3 (2021-12-13)
-------------------

**Dependencies**

* ``com.vaadin 7.7.28`` -> ``7.7.29``

* ``org.apache.logging.log4j:log4j-core:2.14.0`` -> ``2.15.0`` (addresses CVE-2021-44228)

* ``org.apache.logging.log4j:log4j-api:2.14.0`` -> ``2.15.0``