### PR TITLE
Hotfix/1.12.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 ==========
 
+1.12.10 (2023-02-17)
+-------------------
+
+**Added**
+
+**Fixed**
+
+* Add Q_NGS_NANOPORE_SINGLE_SAMPLE_RUN to the list of sample_type excluded from the result tab in LevelComponent
+
 1.12.9 (2022-02-01)
 -------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<version>1.7.1</version>
 	</parent>
 	<artifactId>projectbrowser-portlet</artifactId>
-	<version>1.12.9</version>
+	<version>1.12.10</version>
 	<name>ProjectBrowser Portlet</name>
 	<url>http://github.com/qbicsoftware/projectbrowser-portlet</url>
 	<description>Browse and manage biomedical projects</description>

--- a/src/main/java/life/qbic/projectbrowser/components/LevelComponent.java
+++ b/src/main/java/life/qbic/projectbrowser/components/LevelComponent.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.portlet.PortletSession;
 import life.qbic.portal.portlet.ProjectBrowserPortlet;
 import org.tepi.filtertable.FilterTreeTable;
@@ -367,13 +369,9 @@ public class LevelComponent extends CustomComponent {
 
             for (Sample sample : allSamples) {
               checkedTestSamples.put(sample.getCode(), sample);
-              if (!sample.getSampleTypeCode().equals("Q_TEST_SAMPLE")
-                  && !sample.getSampleTypeCode().equals("Q_MICROARRAY_RUN")
-                  && !sample.getSampleTypeCode().equals("Q_MS_RUN")
-                  && !sample.getSampleTypeCode().equals("Q_BIOLOGICAL_SAMPLE")
-                  && !sample.getSampleTypeCode().equals("Q_BIOLOGICAL_ENTITY")
-                  && !sample.getSampleTypeCode().equals("Q_NGS_SINGLE_SAMPLE_RUN")) {
 
+              if (!Stream.of(BlackListedSampleTypes.values()).collect(Collectors.toList())
+                  .contains(sample.getSampleTypeCode())) {
                 Map<String, String> sampleProperties = sample.getProperties();
                 TestSampleBean newBean = new TestSampleBean();
                 newBean.setCode(sample.getCode());
@@ -1158,5 +1156,53 @@ public class LevelComponent extends CustomComponent {
       map.put(kv[0], kv[1]);
     }
     return map;
+  }
+
+
+  /**
+   * Blacklisted Sample Types
+   * <p>
+   * This enum describes all sample types which refer to raw files and should therefore not to be
+   * shown in the project browser result tab.
+   */
+  private enum BlackListedSampleTypes {
+
+    Q_TEST_SAMPLE("Q_TEST_SAMPLE"), Q_MICROARRAY_RUN("Q_MICROARRAY_RUN"), Q_BIOLOGICAL_SAMPLE(
+        "Q_BIOLOGICAL_SAMPLE"), Q_BIOLOGICAL_ENTITY("Q_BIOLOGICAL_ENTITY"), Q_NGS_SINGLE_SAMPLE_RUN(
+        "Q_NGS_SINGLE_SAMPLE_RUN"), Q_NGS_NANOPORE_SINGLE_SAMPLE_RUN(
+        "Q_NGS_NANOPORE_SINGLE_SAMPLE_RUN");
+
+    /**
+     * Holds the String value of the enum
+     */
+    private final String value;
+
+    /**
+     * Private constructor to create one of the BlacklistedSampleType enum items
+     *
+     * @param value
+     */
+    BlackListedSampleTypes(String value) {
+      this.value = value;
+    }
+
+    /**
+     * Returns to the enum item value
+     *
+     * @return
+     */
+    public String getValue() {
+      return value;
+    }
+
+    /**
+     * Returns a String representation of the enum item
+     *
+     * @return
+     */
+    @Override
+    public String toString() {
+      return this.getValue();
+    }
   }
 }

--- a/src/main/java/life/qbic/projectbrowser/components/LevelComponent.java
+++ b/src/main/java/life/qbic/projectbrowser/components/LevelComponent.java
@@ -369,6 +369,7 @@ public class LevelComponent extends CustomComponent {
             for (Sample sample : allSamples) {
               checkedTestSamples.put(sample.getCode(), sample);
 
+              // We do not want to show raw data in the Result tab, so we blacklist several sample types
               if (!isSampleTypeBlacklisted(sample.getSampleTypeCode())) {
                 Map<String, String> sampleProperties = sample.getProperties();
                 TestSampleBean newBean = new TestSampleBean();

--- a/src/main/java/life/qbic/projectbrowser/components/LevelComponent.java
+++ b/src/main/java/life/qbic/projectbrowser/components/LevelComponent.java
@@ -23,6 +23,7 @@ import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -31,8 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.portlet.PortletSession;
 import life.qbic.portal.portlet.ProjectBrowserPortlet;
 import org.tepi.filtertable.FilterTreeTable;
@@ -370,8 +369,7 @@ public class LevelComponent extends CustomComponent {
             for (Sample sample : allSamples) {
               checkedTestSamples.put(sample.getCode(), sample);
 
-              if (!Stream.of(BlackListedSampleTypes.values()).collect(Collectors.toList())
-                  .contains(sample.getSampleTypeCode())) {
+              if (!isSampleTypeBlacklisted(sample.getSampleTypeCode())) {
                 Map<String, String> sampleProperties = sample.getProperties();
                 TestSampleBean newBean = new TestSampleBean();
                 newBean.setCode(sample.getCode());
@@ -1158,6 +1156,9 @@ public class LevelComponent extends CustomComponent {
     return map;
   }
 
+  public static boolean isSampleTypeBlacklisted(String sampleType){
+    return Arrays.stream(BlackListedSampleTypes.values()).anyMatch(blackListedSampleType -> blackListedSampleType.getValue().equals(sampleType));
+  }
 
   /**
    * Blacklisted Sample Types
@@ -1169,8 +1170,7 @@ public class LevelComponent extends CustomComponent {
 
     Q_TEST_SAMPLE("Q_TEST_SAMPLE"), Q_MICROARRAY_RUN("Q_MICROARRAY_RUN"), Q_BIOLOGICAL_SAMPLE(
         "Q_BIOLOGICAL_SAMPLE"), Q_BIOLOGICAL_ENTITY("Q_BIOLOGICAL_ENTITY"), Q_NGS_SINGLE_SAMPLE_RUN(
-        "Q_NGS_SINGLE_SAMPLE_RUN"), Q_NGS_NANOPORE_SINGLE_SAMPLE_RUN(
-        "Q_NGS_NANOPORE_SINGLE_SAMPLE_RUN");
+        "Q_NGS_SINGLE_SAMPLE_RUN"), Q_NGS_NANOPORE_SINGLE_SAMPLE_RUN("Q_NGS_NANOPORE_SINGLE_SAMPLE_RUN");
 
     /**
      * Holds the String value of the enum

--- a/src/test/java/life/qbic/portal/portlet/LevelComponentTest.java
+++ b/src/test/java/life/qbic/portal/portlet/LevelComponentTest.java
@@ -1,0 +1,22 @@
+package life.qbic.portal.portlet;
+
+import life.qbic.projectbrowser.components.LevelComponent;
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link LevelComponent}.
+ */
+public class LevelComponentTest {
+
+    @Test
+    public void SampleTypeIsBlacklisted() {
+        assertTrue(LevelComponent.isSampleTypeBlacklisted("Q_NGS_NANOPORE_SINGLE_SAMPLE_RUN"));
+    }
+
+    @Test
+    public void SampleTypeIsNotBlacklisted() {
+        assertFalse(LevelComponent.isSampleTypeBlacklisted("Q_NOT_BLACKLISTED_TYPE"));
+    }
+}


### PR DESCRIPTION
**What was changed** 

The Project Browser Portlet has a list of sample_type codes which should not be added to the result tab. 
This PR introduces a new Sample_Type Code `Q_NGS_NANOPORE_SINGLE_SAMPLE_RUN `to the blacklist and moves the list of blacklisted types into a seperate enum with corresponding tests. 
Finally the check itself is handled now by a dedicated method isSampleTypeBlacklisted in the levelcomponent using enum values instead of hardcoded strings.  